### PR TITLE
Fix typo

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -87,7 +87,7 @@
           </figcaption>
         </figure>
         <p>
-          The term <em>brutalism</em> is derived from the French <em>betón brut</em>, meaning “raw concrete”.  Although most brutalist buildings are made from concrete, we're more interested in the term <em>raw</em>.  Concrete brutalist buildings often reflect back the forms used to make them, and their overall design tends to adhere to the concept of <a href="https://en.wikipedia.org/wiki/Truth_to_materials">truth to materials</a>.
+          The term <em>brutalism</em> is derived from the French <em>béton brut</em>, meaning “raw concrete”.  Although most brutalist buildings are made from concrete, we're more interested in the term <em>raw</em>.  Concrete brutalist buildings often reflect back the forms used to make them, and their overall design tends to adhere to the concept of <a href="https://en.wikipedia.org/wiki/Truth_to_materials">truth to materials</a>.
         </p>
         <p>
           A website's materials aren't HTML tags, CSS, or JavaScript code.  Rather, they are its content and the context in which it's consumed.  A website is for a visitor, using a browser, running on a computer to read, watch, listen, or perhaps to interact.  A website that embraces Brutalist Web Design is raw in its focus on <em>content</em>, and prioritization of the website visitor.


### PR DESCRIPTION
This PR fixes a small typo, with *béton brut* being written *betón brut* for the French of *raw concrete*.