### PR TITLE
Modify the book ad to comply with the tenets of brutalist web design

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -234,9 +234,7 @@
               <h2 class="f5 tracked-tight fw3 ttu mt0">11 Practices You Can Start Doing Now</h2>
               <img src="/images/sweng-cover.png" class="w-33 shadow-5" alt="Book Cover for The Senior Software Engineer" nopin="nopin">
               <p class="f4 b">
-                <form method="get" action="http://bit.ly/dcsweng">
-                  <input class="pa2" type="submit" value="Buy Now $25">
-                </form>
+                <a href="https://transactions.sendowl.com/products/24086/D8D2ED13/add_to_cart">Buy Now $25</a>
               </p>
             </aside>
             <p>


### PR DESCRIPTION
Replacing the button with a hyperlink to clarify that the result is a page navigation, and give the user the option to open the link in a new window or tab.
Additionally, changing the url from http://bit.ly/dcsweng to https://transactions.sendowl.com/products/24086/D8D2ED13/add_to_cart skips two redirects, improving performance, and letting the user see the final link target before they click.