### PR TITLE
Update red text in dark mode for better contrast

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -40,7 +40,7 @@ html {
   .light-gray { color: #111111; }
   .mid-gray { color: #666666; }
   .near-black { color: #dddddd; }
-  .red { color: #E7040F; }
+  .red { color: #ff3333; }
 
   .hover-big-light-yellow { } /* Not overridden as this color is used explicitly to mean light yellow on hover */
 


### PR DESCRIPTION
This CSS change adjusts the red color in dark mode to something with a bit more contrast.

Running HTML CodeSniffer against the site, it yielded an error on the red text. With this change, I don't get that error in dark mode any more. I'm honestly not sure how to easily test in non-dark mode to make sure I didn't break that.