### PR TITLE
make form actually submit and not just pretend to be a link.

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -250,10 +250,11 @@
                                               50vw"
                      nopin="nopin"
                      >
-                <p class="f4 b">
-                  <form method="get" action="https://bit.ly/sus-rails">
-                    <input class="pa2" type="submit" value="Buy Now $49.95">
-                  </form>
+                 <form method="get" action="https://sowl.co/boqdo7" class="mv2">
+                   <input class="f5 b pa2 pointer grow" type="submit" value="Buy Now $49.95">
+                 </form>
+                <p>
+                  <a class="f6" href="https://sustainable-rails.com">Learn more…</a>
                 </p>
               </aside>
               <p>


### PR DESCRIPTION
# problem

When changing what book was in the example ad, I changed the form action to be a link to the book's website and
not the action to add it to a shopping cart.

# solution

Restore the form's behavior of adding a book to the shopping cart, but also include a link to the website.
