### PR TITLE
Improve redirected and broken links

### DIFF
--- a/src/html/changelog.html
+++ b/src/html/changelog.html
@@ -61,7 +61,7 @@
           <dt class="lh-title f4 helvetica ttu tracked mt2"><time datetime="2024-04-07">April 4, 2024</time></dt>
           <dd>
             <ul class="pl1 pl3-ns">
-              <li>Changed the example advertisement to my latest book (<a href="https:devbox.computer">Sustainable Dev Environments with Docker and Bash</a>)</li>
+              <li>Changed the example advertisement to my latest book (<a href="https://devbox.computer/">Sustainable Dev Environments with Docker and Bash</a>)</li>
             </ul>
           </dd>
           <dt class="lh-title f4 helvetica ttu tracked mt2"><time datetime="2023-09-20">September 29, 2023</time></dt>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -249,7 +249,7 @@
                    <input class="f5 b pa2 pointer grow" type="submit" value="Buy Now $19.99">
                  </form>
                 <p>
-                  <a class="f6" href="https://devbox.computer/">Learn more…</a>
+                  <a class="f6" href="https://devbox.computer">Learn more…</a>
                 </p>
               </aside>
               <p>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -129,7 +129,7 @@
                 Most websites exist to deliver content for you to consume, either words (such as on this site), or images, such as on Pinterest.  To be true to that nature, the content must be readable in all browsers.  Some screens are very large, while others are very small.  Some browsers, such as <a href="https://en.wikipedia.org/wiki/Screen_reader">screen readers</a>, have no screen at all.
               </p>
               <p>
-                By default, a website that uses <a href="https://www.w3.org/TR/html52/dom.html#elements">HTML as intended</a> and has no custom styling will be readable on all screens and devices. Only the act of design can make the content less readable, though it can certainly make it more.  For example, this website does not use default styles, yet, it is readable on any size screen.
+                By default, a website that uses <a href="https://html.spec.whatwg.org/multipage/dom.html#elements">HTML as intended</a> and has no custom styling will be readable on all screens and devices. Only the act of design can make the content less readable, though it can certainly make it more.  For example, this website does not use default styles, yet, it is readable on any size screen.
               </p>
             </a>
           </section>
@@ -249,7 +249,7 @@
                    <input class="f5 b pa2 pointer grow" type="submit" value="Buy Now $19.99">
                  </form>
                 <p>
-                  <a class="f6" href="https://devbox.computer">Learn more…</a>
+                  <a class="f6" href="https://devbox.computer/">Learn more…</a>
                 </p>
               </aside>
               <p>


### PR DESCRIPTION
- `changelog.html`: Fixed invalid URL scheme in link to book.
- `index.html`: Replace W3.org link with the equivalent official WHATWG standard page.
- ~`index.html`: Added trailing slash to avoid a redirect in book link.~